### PR TITLE
Fixed behavior when conv VIEW in TiDB.

### DIFF
--- a/src/DatabaseStructureFactory.php
+++ b/src/DatabaseStructureFactory.php
@@ -35,7 +35,7 @@ class DatabaseStructureFactory
                     $table = $driver->createTableStructure($dbName, $tableName);
                     break;
                 case 'VIEW':
-                    $table = $driver->createViewStructure($tableName);
+                    $table = $driver->createViewStructure($dbName, $tableName);
                     break;
                 default:
                     continue 2;

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -15,8 +15,9 @@ interface DriverInterface
     public function createTableStructure(string $dbName, string $tableName): TableStructure;
 
     /**
+	 * @param string $dbName
      * @param string $viewName
      * @return ViewStructure
      */
-    public function createViewStructure(string $viewName): ViewStructure;
+    public function createViewStructure(string $dbName, string $viewName): ViewStructure;
 }

--- a/src/Driver/MySQL56Driver.php
+++ b/src/Driver/MySQL56Driver.php
@@ -209,15 +209,16 @@ EOT;
     }
 
     /**
-     * @param string $viewName
+     * @param string $dbName
+	 * @param string $viewName
      * @return ViewStructure
      */
-    public function createViewStructure(string $viewName): ViewStructure
+    public function createViewStructure(string $dbName, string $viewName): ViewStructure
     {
         $createQuery = $this->PDO()->query("SHOW CREATE VIEW $viewName")->fetch()['Create View'];
         return new ViewStructure(
             $viewName,
-            "$createQuery;",
+            str_replace("`$dbName`.", '', "$createQuery;"),
             []
         );
     }


### PR DESCRIPTION
When `SHOW CREATE VIEW` is executed in TiDB, the database name is displayed in `Create View` and the migration fails, so I removed it.