### PR TITLE
TiDBのAUTO_RANDOMに一時的に対応した実装

### DIFF
--- a/src/Driver/DriverAllocator.php
+++ b/src/Driver/DriverAllocator.php
@@ -8,6 +8,7 @@ class DriverAllocator
 {
     const TYPE_MYSQL = 'mysql';
     const TYPE_MARIA_DB = 'mariadb';
+    const TYPE_TIDB = 'tidb';
 
     /**
      * @param \PDO $PDO
@@ -34,6 +35,9 @@ class DriverAllocator
             } else {
                 $version = $split[1];
             }
+        } elseif (strpos($rawVersion, 'TiDB') !== false){
+            $type = self::TYPE_TIDB;
+            $version = $match[0];
         } elseif (strtolower($driverName) === 'mysql') {
             $type = self::TYPE_MYSQL;
             $version = $match[0];
@@ -57,6 +61,11 @@ class DriverAllocator
                         return new MySQL57Driver($PDO);
                     case Semver::satisfies($version, '10.0.*'):
                         return new MySQL56Driver($PDO);
+                }
+            case self::TYPE_TIDB:
+                switch (true) {
+                    case Semver::satisfies($version, '>= 8.0.0'):
+                        return new TiDBTempDriver($PDO);
                 }
         }
 

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -57,7 +57,7 @@ EOT;
             $attribute[] = Attribute::STORED;
         }
 
-        if((bool) preg_match('/PK_AUTO_RANDOM/', $rawPkStatus) && $rawColumn['COLUMN_KEY'] == 'PRI') {
+        if ((bool) preg_match('/PK_AUTO_RANDOM/', $rawPkStatus) && $rawColumn['COLUMN_KEY'] == 'PRI') {
             preg_match_all('/[0-9]+/', $rawPkStatus, $bit_range);
             $auto_random = [
               'AUTO_RANDOM',

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -13,8 +13,6 @@ class TiDBTempDriver extends MySQL80Driver
     protected function createColumnStructureList(string $dbName, string $tableName): array
     {
         $attribute = [];
-        if ((bool) preg_match('/auto_random/', $rawColumn['EXTRA'])) {
-            $attribute[] = Attribute::AUTO_RANDOM;
         $format = <<<EOT
 SELECT *
 FROM information_schema.COLUMNS
@@ -43,7 +41,7 @@ EOT;
 
 
 
-    protected function createColumnStructure(array $rawColumn, array $rawPkStatus = null): ColumnStructureInterface
+    protected function createColumnStructure(array $rawColumn, ?string $rawPkStatus = null): ColumnStructureInterface
     {
         $attribute = [];
         $auto_random = null;
@@ -88,8 +86,8 @@ EOT;
      * @param mixed[] 
      * @return MySQLColumnStructureInterface
      */
-    protected function generateColumnStructure(...)
+    protected function generateColumnStructure(...$values)
     {
-        return new TiDBTempColumnStructure(...);
+        return new TiDBTempColumnStructure(...$values);
     }
 }

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Howyi\Conv\Driver;
+
+use Howyi\Conv\Structure\ColumnStructure\ColumnStructureInterface;
+use Howyi\Conv\Structure\ColumnStructure\TiDBTempColumnStructure;
+use Howyi\Conv\Structure\ColumnStructure\MySQLColumnStructureInterface;
+
+class TiDBTempDriver extends MySQL80Driver
+{
+    protected function createColumnStructureList(string $dbName, string $tableName): array
+    {
+        $attribute = [];
+        if ((bool) preg_match('/auto_random/', $rawColumn['EXTRA'])) {
+            $attribute[] = Attribute::AUTO_RANDOM;
+        $format = <<<EOT
+SELECT *
+FROM information_schema.COLUMNS
+WHERE table_schema = '%s' AND  table_name = '%s'
+ORDER BY ORDINAL_POSITION ASC
+EOT;
+
+        $rawColumnList = $this->PDO()->query(
+            sprintf(
+                $format,
+                $dbName,
+                $tableName
+            )
+        )->fetchAll();
+
+        $rawPkStatus = $this->PDO()->query("SELECT TIDB_ROW_ID_SHARDING_INFO FROM information_schema.TABLES WHERE table_schema = '$dbName'")->fetch();
+
+        $columnStructureList = [];
+
+        foreach ($rawColumnList as $rawColumn) {
+            $columnStructureList[] = $this->createColumnStructure($rawColumn, $rawPkStatus['TIDB_ROW_ID_SHARDING_INFO']);
+        }
+
+        return $columnStructureList;
+    }
+
+
+
+    protected function createColumnStructure(array $rawColumn, array $rawPkStatus = null): ColumnStructureInterface
+    {
+        $attribute = [];
+        $auto_random = null;
+        if ('YES' === $rawColumn['IS_NULLABLE']) {
+            $attribute[] = Attribute::NULLABLE;
+        }
+        if ((bool) preg_match('/unsigned/', $rawColumn['COLUMN_TYPE'])) {
+            $attribute[] = Attribute::UNSIGNED;
+        }
+        if ((bool) preg_match('/STORED/', $rawColumn['EXTRA'])) {
+            $attribute[] = Attribute::STORED;
+        }
+
+        if((bool) preg_match('/PK_AUTO_RANDOM/', $rawPkStatus) && $rawColumn['COLUMN_KEY'] == 'PRI') {
+            preg_match_all('/[0-9]+/', $rawPkStatus, $bit_range);
+            $auto_random = [
+              'AUTO_RANDOM',
+                $bit_range[0][0],
+                $bit_range[0][1]
+            ];
+        }
+
+        $collationName = $rawColumn['COLLATION_NAME'];
+        $generationExpression = empty($rawColumn['GENERATION_EXPRESSION']) ? null : $rawColumn['GENERATION_EXPRESSION'];
+
+        return $this->generateColumnStructure(
+            $rawColumn['COLUMN_NAME'],
+            str_replace(' unsigned', '', $rawColumn['COLUMN_TYPE']),
+            $rawColumn['COLUMN_DEFAULT'],
+            $rawColumn['COLUMN_COMMENT'],
+            $attribute,
+            $collationName,
+            $generationExpression,
+            [],
+            $auto_random
+        );
+    }
+
+
+
+    /**
+     * @param mixed[] 
+     * @return MySQLColumnStructureInterface
+     */
+    protected function generateColumnStructure(...)
+    {
+        return new TiDBTempColumnStructure(...);
+    }
+}

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -5,6 +5,8 @@ namespace Howyi\Conv\Driver;
 use Howyi\Conv\Structure\ColumnStructure\ColumnStructureInterface;
 use Howyi\Conv\Structure\ColumnStructure\TiDBTempColumnStructure;
 use Howyi\Conv\Structure\ColumnStructure\MySQLColumnStructureInterface;
+use Howyi\Conv\Structure\TableStructure;
+use Howyi\Conv\Structure\Attribute;
 
 class TiDBTempDriver extends MySQL80Driver
 {

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -28,7 +28,7 @@ EOT;
             )
         )->fetchAll();
 
-        $rawPkStatus = $this->PDO()->query("SELECT TIDB_ROW_ID_SHARDING_INFO FROM information_schema.TABLES WHERE table_schema = '$dbName'")->fetch();
+        $rawPkStatus = $this->PDO()->query("SELECT TIDB_ROW_ID_SHARDING_INFO FROM information_schema.TABLES WHERE table_name = '$tableName'")->fetch();
 
         $columnStructureList = [];
 

--- a/src/Structure/ColumnStructure/TiDBTempColumnStructure.php
+++ b/src/Structure/ColumnStructure/TiDBTempColumnStructure.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Howyi\Conv\Structure\ColumnStructure;
+
+use Howyi\Conv\Structure\Attribute;
+use Howyi\Conv\Util\SchemaKey;
+
+class TiDBTempColumnStructure implements MySQLColumnStructureInterface
+{
+    use MySQL56ColumnStructureTrait;
+
+    public $generationExpression;
+    public $auto_random;
+
+    /**
+     * @param string      $field
+     * @param string      $type
+     * @param mixed       $default
+     * @param string      $comment
+     * @param array       $attribute
+     * @param string|null $collationName
+     * @param string|null $generationExpression
+     * @param array       $properties
+     */
+    public function __construct(
+        string $field,
+        string $type,
+        $default,
+        string $comment,
+        array $attribute,
+        ?string $collationName,
+        ?string $generationExpression,
+        array $properties,
+        ?array $auto_random
+    ) {
+        $this->field = $field;
+        $this->type = $type;
+        $this->default = $default;
+        $this->comment = $comment;
+        $this->attribute = $attribute;
+        $this->collationName = $collationName;
+        $this->generationExpression = $generationExpression;
+        $this->properties = $properties;
+        $this->auto_random = $auto_random;
+    }
+
+    /**
+     * @return string
+     */
+    public function generateBaseQuery(): string
+    {
+        $query = [$this->type];
+        if ($this->isUnsigned() === true) {
+            $query[] = 'UNSIGNED';
+        }
+
+        if ($this->collationName !== null) {
+            $query[] = 'COLLATE';
+            $query[] = $this->collationName;
+        }
+
+        if ($this->generationExpression !== null) {
+            $query[] = 'AS';
+            $query[] = "($this->generationExpression)";
+        }
+
+        if ($this->isStored() === true) {
+            $query[] = 'STORED';
+        }
+
+        if ($this->isNullable() === false) {
+            $query[] = 'NOT NULL';
+        } elseif ($this->isForceNull()) {
+            $query[] = 'NULL';
+        }
+
+        if ($this->generationExpression === null) {
+            if ($this->default !== null) {
+                $query[] = 'DEFAULT';
+                $query[] = $this->getDefault();
+            } elseif ($this->isNullable() === true) {
+                $query[] = 'DEFAULT NULL';
+            }
+        }
+
+        if(!is_null($this->auto_random)) {
+            $query[] = $this->auto_random[0] . '(' . $this->auto_random[1] . ',' . $this->auto_random[2] . ')';
+        }
+
+        $query[] = 'COMMENT';
+        $query[] = "'$this->comment'";
+        return implode(' ', $query);
+    }
+
+    /**
+     * @param TiDBTempColumnStructure $target
+     * @return bool
+     */
+    public function isChanged(TiDBTempColumnStructure $target): bool
+    {
+        if ($this->type === $target->type and
+            $this->comment === $target->comment and
+            $this->isNullable() === $target->isNullable() and
+            $this->isUnsigned() === $target->isUnsigned() and
+            $this->default === $target->default and
+            $this->isAutoRandom() === $target->isAutoRandom() and
+            $this->collationName === $this->collationName and
+            $this->generationExpression === $this->generationExpression and
+            $this->isStored() === $this->isStored()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAutoRandom(): bool
+    {
+        return !is_null($this->auto_random);
+    }
+}

--- a/src/Structure/ColumnStructure/TiDBTempColumnStructure.php
+++ b/src/Structure/ColumnStructure/TiDBTempColumnStructure.php
@@ -21,6 +21,7 @@ class TiDBTempColumnStructure implements MySQLColumnStructureInterface
      * @param string|null $collationName
      * @param string|null $generationExpression
      * @param array       $properties
+     * @param array       $auto_random
      */
     public function __construct(
         string $field,

--- a/src/Util/SchemaKey.php
+++ b/src/Util/SchemaKey.php
@@ -13,6 +13,7 @@ class SchemaKey
     const TABLE_DEFAULT_CHARSET = 'default_charset';
     const TABLE_COLLATE         = 'collate';
     const TABLE_PARTITION       = 'partition';
+    const TABLE_AUTO_RANDOM     = 'auto_random';
 
     const TABLE_KEYS = [
         self::TABLE_TYPE,
@@ -24,6 +25,7 @@ class SchemaKey
         self::TABLE_DEFAULT_CHARSET,
         self::TABLE_COLLATE,
         self::TABLE_PARTITION,
+        self::TABLE_AUTO_RANDOM,
     ];
 
     const TABLE_REQUIRE_KEYS = [
@@ -39,6 +41,7 @@ class SchemaKey
         self::TABLE_DEFAULT_CHARSET,
         self::TABLE_COLLATE,
         self::TABLE_PARTITION,
+        self::TABLE_AUTO_RANDOM,
     ];
 
     const COLUMN_TYPE      = 'type';


### PR DESCRIPTION
## 概要
TiDBにはAUTO_RANDOMのクエリがあるが、従来動作ではAUTO_RANDOMを扱うことができていなかったため
一時的にMySQLの実装にAUTO_RANDOM対応を追加した
テストコードはTiDBのDockerイメージがhubになく、また構成が難しいためTODOとなっている
