### PR TITLE
fix: Deprecated error in PHP 8.4

### DIFF
--- a/src/CreateQueryReflector.php
+++ b/src/CreateQueryReflector.php
@@ -18,7 +18,7 @@ class CreateQueryReflector
         string $dbName,
         string $path,
         OperatorInterface $operator,
-        callable $filter = null
+        ?callable $filter = null
     ) {
         $dbs = DatabaseStructureFactory::fromPDO(
             $pdo,

--- a/src/DatabaseStructureFactory.php
+++ b/src/DatabaseStructureFactory.php
@@ -21,7 +21,7 @@ class DatabaseStructureFactory
     public static function fromPDO(
         \PDO $pdo,
         string $dbName,
-        callable $filter = null
+        ?callable $filter = null
     ): DatabaseStructure {
         $rawTableList = $pdo->query(
             "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = '$dbName'"
@@ -60,7 +60,7 @@ class DatabaseStructureFactory
         \PDO $pdo,
         string $path,
         OperatorInterface $operator,
-        callable $filter = null,
+        ?callable $filter = null,
         $drop = true
     ): DatabaseStructure {
         $operator->output('<comment>Generate temporary database</>');


### PR DESCRIPTION
Fixed `Implicitly nullable parameter` Deprecated error in PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

```
PHP Deprecated:  Howyi\Conv\DatabaseStructureFactory::fromPDO(): Implicitly marking parameter $filter as nullable is deprecated, the explicit nullable type must be used instead in /.../vendor/howyi/conv/src/DatabaseStructureFactory.php on line 21
PHP Deprecated:  Howyi\Conv\DatabaseStructureFactory::fromSqlDir(): Implicitly marking parameter $filter as nullable is deprecated, the explicit nullable type must be used instead in /.../vendor/howyi/conv/src/DatabaseStructureFactory.php on line 59
PHP Deprecated:  Howyi\Conv\CreateQueryReflector::fromPDO(): Implicitly marking parameter $filter as nullable is deprecated, the explicit nullable type must be used instead in /.../vendor/howyi/conv/src/CreateQueryReflector.php on line 16
```