### PR TITLE
fix: PHP 8.4 Additional deprecated message

### DIFF
--- a/src/Migration/Line/IndexAllMigrationLine.php
+++ b/src/Migration/Line/IndexAllMigrationLine.php
@@ -14,8 +14,8 @@ class IndexAllMigrationLine
      * @param bool
      */
     public function __construct(
-        IndexDropMigrationLine $first = null,
-        IndexAddMigrationLine $last = null
+        ?IndexDropMigrationLine $first = null,
+        ?IndexAddMigrationLine $last = null
     ) {
         $this->first = $first;
         $this->last = $last;


### PR DESCRIPTION
- fixes additional of https://github.com/howyi/conv/pull/63

```
Deprecated: Howyi\Conv\Migration\Line\IndexAllMigrationLine::__construct(): Implicitly marking parameter $first as nullable is deprecated, the explicit nullable type must be used instead in vendor/howyi/conv/src/Migration/Line/IndexAllMigrationLine.php on line 16

Deprecated: Howyi\Conv\Migration\Line\IndexAllMigrationLine::__construct(): Implicitly marking parameter $last as nullable is deprecated, the explicit nullable type must be used instead in vendor/howyi/conv/src/Migration/Line/IndexAllMigrationLine.php on line 16
```

tested with 

```sh
find vendor/howyi/conv/ -type f -name "*.php" | xargs php -l
```