### PR TITLE
Support TiDB TTL

### DIFF
--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -28,8 +28,8 @@ class TiDBTempDriver extends MySQL80Driver
             $ttlQuery = implode(' ', $matches[1]);
         } else {
             $nativeQuery = preg_replace('/\/\*(?!T!\[ttl\]).*?\*\//is', '', $createQuery);
-            $nativeQuery = preg_replace("/'(?:''|\\\\.|[^'])*'/s", '', $nativeQuery);
-            if (!preg_match('/\bTTL\s*=/i', $nativeQuery)) {
+            $nativeQueryWithoutStrings = preg_replace("/'(?:''|\\\\.|[^'])*'/s", '', $nativeQuery);
+            if (!preg_match('/\bTTL\s*=/i', $nativeQueryWithoutStrings)) {
                 return null;
             }
             $ttlQuery = $nativeQuery;

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -23,8 +23,16 @@ class TiDBTempDriver extends MySQL80Driver
     protected function createTTLStructure(string $createQuery): ?TableTTLStructure
     {
         $ttlQuery = $createQuery;
-        if (preg_match_all('/\/\*T!\[ttl\](.*?)\*\//is', $createQuery, $matches)) {
+        $hasTTLComment = preg_match_all('/\/\*T!\[ttl\](.*?)\*\//is', $createQuery, $matches);
+        if ($hasTTLComment) {
             $ttlQuery = implode(' ', $matches[1]);
+        } else {
+            $nativeQuery = preg_replace('/\/\*(?!T!\[ttl\]).*?\*\//is', '', $createQuery);
+            $nativeQuery = preg_replace("/'(?:''|\\\\.|[^'])*'/s", '', $nativeQuery);
+            if (!preg_match('/\bTTL\s*=/i', $nativeQuery)) {
+                return null;
+            }
+            $ttlQuery = $nativeQuery;
         }
 
         if (
@@ -98,7 +106,7 @@ EOT;
         if ((bool) preg_match('/PK_AUTO_RANDOM/', $rawPkStatus) && $rawColumn['COLUMN_KEY'] == 'PRI') {
             preg_match_all('/[0-9]+/', $rawPkStatus, $bit_range);
             $auto_random = [
-              'AUTO_RANDOM',
+                'AUTO_RANDOM',
                 $bit_range[0][0],
                 $bit_range[0][1]
             ];
@@ -123,7 +131,7 @@ EOT;
 
 
     /**
-     * @param mixed[] 
+     * @param mixed[]
      * @return MySQLColumnStructureInterface
      */
     protected function generateColumnStructure(...$values)

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -6,10 +6,50 @@ use Howyi\Conv\Structure\ColumnStructure\ColumnStructureInterface;
 use Howyi\Conv\Structure\ColumnStructure\TiDBTempColumnStructure;
 use Howyi\Conv\Structure\ColumnStructure\MySQLColumnStructureInterface;
 use Howyi\Conv\Structure\TableStructure;
+use Howyi\Conv\Structure\TableTTLStructure;
 use Howyi\Conv\Structure\Attribute;
 
 class TiDBTempDriver extends MySQL80Driver
 {
+    public function createTableStructure(string $dbName, string $tableName): TableStructure
+    {
+        $tableStructure = parent::createTableStructure($dbName, $tableName);
+        $createQuery = $this->PDO()->query("SHOW CREATE TABLE $tableName")->fetch()[1];
+        $tableStructure->setTTL($this->createTTLStructure($createQuery));
+
+        return $tableStructure;
+    }
+
+    protected function createTTLStructure(string $createQuery): ?TableTTLStructure
+    {
+        $ttlQuery = $createQuery;
+        if (preg_match_all('/\/\*T!\[ttl\](.*?)\*\//is', $createQuery, $matches)) {
+            $ttlQuery = implode(' ', $matches[1]);
+        }
+
+        if (
+            !preg_match(
+                '/TTL\s*=\s*(.+?)(?=\s+TTL_ENABLE\s*=|\s+TTL_JOB_INTERVAL\s*=|\s*;|\s+PARTITION\b|$)/is',
+                $ttlQuery,
+                $ttlMatch
+            )
+        ) {
+            return null;
+        }
+
+        $enable = null;
+        if (preg_match('/TTL_ENABLE\s*=\s*\'?([^\'\s;]+)\'?/i', $ttlQuery, $enableMatch)) {
+            $enable = $enableMatch[1];
+        }
+
+        $jobInterval = null;
+        if (preg_match('/TTL_JOB_INTERVAL\s*=\s*\'?([^\';]+)\'?/i', $ttlQuery, $jobIntervalMatch)) {
+            $jobInterval = trim($jobIntervalMatch[1]);
+        }
+
+        return new TableTTLStructure($ttlMatch[1], $enable, $jobInterval);
+    }
+
     protected function createColumnStructureList(string $dbName, string $tableName): array
     {
         $attribute = [];

--- a/src/Generator/TableAlterMigrationGenerator.php
+++ b/src/Generator/TableAlterMigrationGenerator.php
@@ -11,6 +11,7 @@ use Howyi\Conv\Migration\Line\TableCommentMigrationLine;
 use Howyi\Conv\Migration\Line\TableEngineMigrationLine;
 use Howyi\Conv\Migration\Line\TableCollateMigrationLine;
 use Howyi\Conv\Migration\Line\TableDefaultCharsetMigrationLine;
+use Howyi\Conv\Migration\Line\TableTTLMigrationLine;
 use Howyi\Conv\Migration\Table\MigrationLineList;
 use Howyi\Conv\Migration\Table\TableAlterMigration;
 use Howyi\Conv\Structure\TableStructure;
@@ -148,6 +149,17 @@ class TableAlterMigrationGenerator
         if ($beforeTable->getCollate() !== $afterTable->getCollate()) {
             $migrationLineList->add(
                 new TableCollateMigrationLine($beforeTable->getCollate(), $afterTable->getCollate())
+            );
+        }
+        $beforeTTL = $beforeTable->getTTL();
+        $afterTTL = $afterTable->getTTL();
+        if (
+            (is_null($beforeTTL) && !is_null($afterTTL))
+            || (!is_null($beforeTTL) && is_null($afterTTL))
+            || (!is_null($beforeTTL) && $beforeTTL->isChanged($afterTTL))
+        ) {
+            $migrationLineList->add(
+                new TableTTLMigrationLine($beforeTTL, $afterTTL)
             );
         }
         if ($indexAllMigration->isFirstExist()) {

--- a/src/Migration/Line/SeparateMigrationLineInterface.php
+++ b/src/Migration/Line/SeparateMigrationLineInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Howyi\Conv\Migration\Line;
+
+interface SeparateMigrationLineInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getSeparateUp(): array;
+
+    /**
+     * @return string[]
+     */
+    public function getSeparateDown(): array;
+}

--- a/src/Migration/Line/TableTTLMigrationLine.php
+++ b/src/Migration/Line/TableTTLMigrationLine.php
@@ -4,8 +4,14 @@ namespace Howyi\Conv\Migration\Line;
 
 use Howyi\Conv\Structure\TableTTLStructure;
 
-class TableTTLMigrationLine extends AbstractMigrationLine
+/**
+ * ALTER TABLE ~ TTL ~
+ */
+class TableTTLMigrationLine extends AbstractMigrationLine implements SeparateMigrationLineInterface
 {
+    private $separateUpLineList = [];
+    private $separateDownLineList = [];
+
     /**
      * @param TableTTLStructure|null $before
      * @param TableTTLStructure|null $after
@@ -15,12 +21,18 @@ class TableTTLMigrationLine extends AbstractMigrationLine
         ?TableTTLStructure $after
     ) {
         if ($this->isDefinitionChanged($before, $after)) {
-            $this->upLineList[] = $this->toQuery(
+            $this->addDefinitionLine(
+                $this->upLineList,
+                $this->separateUpLineList,
                 $after,
+                $this->shouldIncludeDefaultEnable($before, $after),
                 $this->shouldIncludeDefaultJobInterval($before, $after)
             );
-            $this->downLineList[] = $this->toQuery(
+            $this->addDefinitionLine(
+                $this->downLineList,
+                $this->separateDownLineList,
                 $before,
+                $this->shouldIncludeDefaultEnable($after, $before),
                 $this->shouldIncludeDefaultJobInterval($after, $before)
             );
             return;
@@ -31,8 +43,41 @@ class TableTTLMigrationLine extends AbstractMigrationLine
             $this->downLineList[] = $this->toEnableQuery($before);
         }
         if ($this->getJobInterval($before) !== $this->getJobInterval($after)) {
-            $this->upLineList[] = $this->toJobIntervalQuery($after);
-            $this->downLineList[] = $this->toJobIntervalQuery($before);
+            $this->separateUpLineList[] = $this->toJobIntervalQuery($after);
+            $this->separateDownLineList[] = $this->toJobIntervalQuery($before);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSeparateUp(): array
+    {
+        return $this->separateUpLineList;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSeparateDown(): array
+    {
+        return $this->separateDownLineList;
+    }
+
+    private function addDefinitionLine(
+        array &$lineList,
+        array &$separateLineList,
+        ?TableTTLStructure $ttl,
+        bool $includeDefaultEnable,
+        bool $includeDefaultJobInterval
+    ): void {
+        if (is_null($ttl)) {
+            $lineList[] = 'REMOVE TTL';
+            return;
+        }
+        $lineList[] = $ttl->toAlterQuery($includeDefaultEnable);
+        if ($includeDefaultJobInterval || !is_null($ttl->getJobInterval())) {
+            $separateLineList[] = $this->toJobIntervalQuery($ttl);
         }
     }
 
@@ -46,13 +91,14 @@ class TableTTLMigrationLine extends AbstractMigrationLine
         return $before->getExpression() !== $after->getExpression();
     }
 
-    private function toQuery(
-        ?TableTTLStructure $ttl,
-        bool $includeDefaultJobInterval = false
-    ): string {
-        return is_null($ttl)
-            ? 'REMOVE TTL'
-            : $ttl->toQuery($includeDefaultJobInterval);
+    private function shouldIncludeDefaultEnable(
+        ?TableTTLStructure $before,
+        ?TableTTLStructure $after
+    ): bool {
+        return !is_null($before)
+            && !is_null($after)
+            && !is_null($before->getEnable())
+            && is_null($after->getEnable());
     }
 
     private function shouldIncludeDefaultJobInterval(

--- a/src/Migration/Line/TableTTLMigrationLine.php
+++ b/src/Migration/Line/TableTTLMigrationLine.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Howyi\Conv\Migration\Line;
+
+use Howyi\Conv\Structure\TableTTLStructure;
+
+class TableTTLMigrationLine extends AbstractMigrationLine
+{
+    /**
+     * @param TableTTLStructure|null $before
+     * @param TableTTLStructure|null $after
+     */
+    public function __construct(
+        ?TableTTLStructure $before,
+        ?TableTTLStructure $after
+    ) {
+        if ($this->isDefinitionChanged($before, $after)) {
+            $this->upLineList[] = $this->toQuery(
+                $after,
+                $this->shouldIncludeDefaultJobInterval($before, $after)
+            );
+            $this->downLineList[] = $this->toQuery(
+                $before,
+                $this->shouldIncludeDefaultJobInterval($after, $before)
+            );
+            return;
+        }
+
+        if ($this->getEnable($before) !== $this->getEnable($after)) {
+            $this->upLineList[] = $this->toEnableQuery($after);
+            $this->downLineList[] = $this->toEnableQuery($before);
+        }
+        if ($this->getJobInterval($before) !== $this->getJobInterval($after)) {
+            $this->upLineList[] = $this->toJobIntervalQuery($after);
+            $this->downLineList[] = $this->toJobIntervalQuery($before);
+        }
+    }
+
+    private function isDefinitionChanged(
+        ?TableTTLStructure $before,
+        ?TableTTLStructure $after
+    ): bool {
+        if (is_null($before) || is_null($after)) {
+            return true;
+        }
+        return $before->getExpression() !== $after->getExpression();
+    }
+
+    private function toQuery(
+        ?TableTTLStructure $ttl,
+        bool $includeDefaultJobInterval = false
+    ): string {
+        return is_null($ttl)
+            ? 'REMOVE TTL'
+            : $ttl->toQuery($includeDefaultJobInterval);
+    }
+
+    private function shouldIncludeDefaultJobInterval(
+        ?TableTTLStructure $before,
+        ?TableTTLStructure $after
+    ): bool {
+        return !is_null($before)
+            && !is_null($after)
+            && !is_null($before->getJobInterval())
+            && is_null($after->getJobInterval());
+    }
+
+    private function getEnable(?TableTTLStructure $ttl): string
+    {
+        return is_null($ttl) || is_null($ttl->getEnable())
+            ? 'ON'
+            : $ttl->getEnable();
+    }
+
+    private function getJobInterval(?TableTTLStructure $ttl): ?string
+    {
+        return is_null($ttl) ? null : $ttl->getJobInterval();
+    }
+
+    private function toEnableQuery(?TableTTLStructure $ttl): string
+    {
+        return "TTL_ENABLE = '" . $this->getEnable($ttl) . "'";
+    }
+
+    private function toJobIntervalQuery(?TableTTLStructure $ttl): string
+    {
+        if (is_null($ttl) || is_null($ttl->getJobInterval())) {
+            // REMOVE TTL_JOB_INTERVAL 構文がないため、TiDB のデフォルト値に戻す。
+            return "TTL_JOB_INTERVAL = '" . TableTTLStructure::DEFAULT_JOB_INTERVAL . "'";
+        }
+        $jobInterval = str_replace("'", "''", $ttl->getJobInterval());
+        return "TTL_JOB_INTERVAL = '$jobInterval'";
+    }
+}

--- a/src/Migration/Line/TableTTLMigrationLine.php
+++ b/src/Migration/Line/TableTTLMigrationLine.php
@@ -20,31 +20,23 @@ class TableTTLMigrationLine extends AbstractMigrationLine implements SeparateMig
         ?TableTTLStructure $before,
         ?TableTTLStructure $after
     ) {
-        if ($this->isDefinitionChanged($before, $after)) {
+        if (
+            $this->isDefinitionChanged($before, $after)
+            || $this->getEnable($before) !== $this->getEnable($after)
+            || $this->getJobInterval($before) !== $this->getJobInterval($after)
+        ) {
             $this->addDefinitionLine(
                 $this->upLineList,
-                $this->separateUpLineList,
                 $after,
                 $this->shouldIncludeDefaultEnable($before, $after),
                 $this->shouldIncludeDefaultJobInterval($before, $after)
             );
             $this->addDefinitionLine(
                 $this->downLineList,
-                $this->separateDownLineList,
                 $before,
                 $this->shouldIncludeDefaultEnable($after, $before),
                 $this->shouldIncludeDefaultJobInterval($after, $before)
             );
-            return;
-        }
-
-        if ($this->getEnable($before) !== $this->getEnable($after)) {
-            $this->upLineList[] = $this->toEnableQuery($after);
-            $this->downLineList[] = $this->toEnableQuery($before);
-        }
-        if ($this->getJobInterval($before) !== $this->getJobInterval($after)) {
-            $this->separateUpLineList[] = $this->toJobIntervalQuery($after);
-            $this->separateDownLineList[] = $this->toJobIntervalQuery($before);
         }
     }
 
@@ -66,7 +58,6 @@ class TableTTLMigrationLine extends AbstractMigrationLine implements SeparateMig
 
     private function addDefinitionLine(
         array &$lineList,
-        array &$separateLineList,
         ?TableTTLStructure $ttl,
         bool $includeDefaultEnable,
         bool $includeDefaultJobInterval
@@ -75,10 +66,10 @@ class TableTTLMigrationLine extends AbstractMigrationLine implements SeparateMig
             $lineList[] = 'REMOVE TTL';
             return;
         }
-        $lineList[] = $ttl->toAlterQuery($includeDefaultEnable);
-        if ($includeDefaultJobInterval || !is_null($ttl->getJobInterval())) {
-            $separateLineList[] = $this->toJobIntervalQuery($ttl);
-        }
+        $lineList[] = $ttl->toQuery(
+            $includeDefaultEnable,
+            $includeDefaultJobInterval
+        );
     }
 
     private function isDefinitionChanged(
@@ -121,20 +112,5 @@ class TableTTLMigrationLine extends AbstractMigrationLine implements SeparateMig
     private function getJobInterval(?TableTTLStructure $ttl): ?string
     {
         return is_null($ttl) ? null : $ttl->getJobInterval();
-    }
-
-    private function toEnableQuery(?TableTTLStructure $ttl): string
-    {
-        return "TTL_ENABLE = '" . $this->getEnable($ttl) . "'";
-    }
-
-    private function toJobIntervalQuery(?TableTTLStructure $ttl): string
-    {
-        if (is_null($ttl) || is_null($ttl->getJobInterval())) {
-            // REMOVE TTL_JOB_INTERVAL 構文がないため、TiDB のデフォルト値に戻す。
-            return "TTL_JOB_INTERVAL = '" . TableTTLStructure::DEFAULT_JOB_INTERVAL . "'";
-        }
-        $jobInterval = str_replace("'", "''", $ttl->getJobInterval());
-        return "TTL_JOB_INTERVAL = '$jobInterval'";
     }
 }

--- a/src/Migration/Table/MigrationLineList.php
+++ b/src/Migration/Table/MigrationLineList.php
@@ -3,6 +3,7 @@
 namespace Howyi\Conv\Migration\Table;
 
 use Howyi\Conv\Migration\Line\MigrationLineInterface;
+use Howyi\Conv\Migration\Line\SeparateMigrationLineInterface;
 
 class MigrationLineList
 {
@@ -47,5 +48,39 @@ class MigrationLineList
             $downLineList = array_merge($downLineList, $migrationLine->getDown());
         }
         return '  ' . join(',' . PHP_EOL . '  ', $downLineList);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSeparateUp(): array
+    {
+        $separateUpLineList = [];
+        foreach ($this->migrationLineList as $migrationLine) {
+            if ($migrationLine instanceof SeparateMigrationLineInterface) {
+                $separateUpLineList = array_merge(
+                    $separateUpLineList,
+                    $migrationLine->getSeparateUp()
+                );
+            }
+        }
+        return $separateUpLineList;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSeparateDown(): array
+    {
+        $separateDownLineList = [];
+        foreach (array_reverse($this->migrationLineList) as $migrationLine) {
+            if ($migrationLine instanceof SeparateMigrationLineInterface) {
+                $separateDownLineList = array_merge(
+                    $separateDownLineList,
+                    $migrationLine->getSeparateDown()
+                );
+            }
+        }
+        return $separateDownLineList;
     }
 }

--- a/src/Migration/Table/TableAlterMigration.php
+++ b/src/Migration/Table/TableAlterMigration.php
@@ -56,6 +56,15 @@ class TableAlterMigration extends AbstractTableMigration
         }
         $this->up .= ';';
         $this->down .= ';';
+
+        foreach ($migrationLineList->getSeparateUp() as $line) {
+            $this->up .= PHP_EOL . sprintf($queryHeaderTemplate, $beforeTableName);
+            $this->up .= PHP_EOL . '  ' . $line . ';';
+        }
+        foreach ($migrationLineList->getSeparateDown() as $line) {
+            $this->down .= PHP_EOL . sprintf($queryHeaderTemplate, $afterTableName);
+            $this->down .= PHP_EOL . '  ' . $line . ';';
+        }
     }
 
     /**

--- a/src/Migration/Table/TableCreateMigration.php
+++ b/src/Migration/Table/TableCreateMigration.php
@@ -34,6 +34,9 @@ class TableCreateMigration extends AbstractTableMigration
         $createQueryFooter .= " DEFAULT CHARSET=$tableStructure->defaultCharset";
         $createQueryFooter .= " COLLATE=$tableStructure->collate";
         $createQueryFooter .= " COMMENT='$tableStructure->comment'";
+        if (!is_null($tableStructure->getTTL())) {
+            $createQueryFooter .= ' ' . $tableStructure->getTTL()->toQuery();
+        }
         if (!is_null($tableStructure->getPartition())) {
             $partitionQuery = $tableStructure->getPartition()->getQuery();
             $partitionQuery = sprintf("/*!50100 %s  */", $partitionQuery);

--- a/src/Structure/TableStructure.php
+++ b/src/Structure/TableStructure.php
@@ -98,6 +98,22 @@ class TableStructure implements TableStructureInterface
         return $this->properties;
     }
 
+    public function getTTL(): ?TableTTLStructure
+    {
+        return array_key_exists('tidb_ttl', $this->properties)
+            ? $this->properties['tidb_ttl']
+            : null;
+    }
+
+    public function setTTL(?TableTTLStructure $ttl): void
+    {
+        if (is_null($ttl)) {
+            unset($this->properties['tidb_ttl']);
+            return;
+        }
+        $this->properties['tidb_ttl'] = $ttl;
+    }
+
     /**
      * @return array
      */

--- a/src/Structure/TableStructure.php
+++ b/src/Structure/TableStructure.php
@@ -98,6 +98,9 @@ class TableStructure implements TableStructureInterface
         return $this->properties;
     }
 
+    /**
+     * @return TableTTLStructure|null
+     */
     public function getTTL(): ?TableTTLStructure
     {
         return array_key_exists('tidb_ttl', $this->properties)
@@ -105,6 +108,9 @@ class TableStructure implements TableStructureInterface
             : null;
     }
 
+    /**
+     * @param TableTTLStructure|null $ttl
+     */
     public function setTTL(?TableTTLStructure $ttl): void
     {
         if (is_null($ttl)) {

--- a/src/Structure/TableTTLStructure.php
+++ b/src/Structure/TableTTLStructure.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Howyi\Conv\Structure;
+
+class TableTTLStructure
+{
+    public const DEFAULT_JOB_INTERVAL = '1h';
+
+    /** @var string */
+    private $expression;
+
+    /** @var string|null */
+    private $enable;
+
+    /** @var string|null */
+    private $jobInterval;
+
+    public function __construct(
+        string $expression,
+        ?string $enable = null,
+        ?string $jobInterval = null
+    ) {
+        $this->expression = trim($expression);
+        $this->enable = is_null($enable) ? null : strtoupper($enable);
+        $this->jobInterval = $jobInterval;
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function getEnable(): ?string
+    {
+        return $this->enable;
+    }
+
+    public function getJobInterval(): ?string
+    {
+        return $this->jobInterval;
+    }
+
+    public function isChanged(?TableTTLStructure $target): bool
+    {
+        if (is_null($target)) {
+            return true;
+        }
+        return $this->expression !== $target->expression
+            || $this->normalizedEnable() !== $target->normalizedEnable()
+            || $this->normalizedJobInterval() !== $target->normalizedJobInterval();
+    }
+
+    public function toQuery(bool $includeDefaultJobInterval = false): string
+    {
+        $query = 'TTL = ' . $this->expression;
+        if (!is_null($this->enable)) {
+            $query .= " TTL_ENABLE = '{$this->enable}'";
+        }
+        if (!is_null($this->jobInterval)) {
+            $query .= " TTL_JOB_INTERVAL = '" . $this->escapeString($this->jobInterval) . "'";
+        } elseif ($includeDefaultJobInterval) {
+            $query .= " TTL_JOB_INTERVAL = '" . self::DEFAULT_JOB_INTERVAL . "'";
+        }
+        return $query;
+    }
+
+    private function normalizedEnable(): string
+    {
+        return is_null($this->enable) ? 'ON' : $this->enable;
+    }
+
+    private function normalizedJobInterval(): string
+    {
+        return is_null($this->jobInterval)
+            ? self::DEFAULT_JOB_INTERVAL
+            : $this->jobInterval;
+    }
+
+    private function escapeString(string $value): string
+    {
+        return str_replace("'", "''", $value);
+    }
+}

--- a/src/Structure/TableTTLStructure.php
+++ b/src/Structure/TableTTLStructure.php
@@ -50,16 +50,31 @@ class TableTTLStructure
             || $this->normalizedJobInterval() !== $target->normalizedJobInterval();
     }
 
-    public function toQuery(bool $includeDefaultJobInterval = false): string
-    {
-        $query = 'TTL = ' . $this->expression;
+    public function toQuery(
+        bool $includeDefaultEnable = false,
+        bool $includeDefaultJobInterval = false
+    ): string {
+        $query = $this->toAlterQuery($includeDefaultEnable);
         if (!is_null($this->enable)) {
             $query .= " TTL_ENABLE = '{$this->enable}'";
+        } elseif ($includeDefaultEnable) {
+            $query .= " TTL_ENABLE = 'ON'";
         }
         if (!is_null($this->jobInterval)) {
             $query .= " TTL_JOB_INTERVAL = '" . $this->escapeString($this->jobInterval) . "'";
         } elseif ($includeDefaultJobInterval) {
             $query .= " TTL_JOB_INTERVAL = '" . self::DEFAULT_JOB_INTERVAL . "'";
+        }
+        return $query;
+    }
+
+    public function toAlterQuery(bool $includeDefaultEnable = false): string
+    {
+        $query = 'TTL = ' . $this->expression;
+        if (!is_null($this->enable)) {
+            $query .= " TTL_ENABLE = '{$this->enable}'";
+        } elseif ($includeDefaultEnable) {
+            $query .= " TTL_ENABLE = 'ON'";
         }
         return $query;
     }

--- a/src/Structure/TableTTLStructure.php
+++ b/src/Structure/TableTTLStructure.php
@@ -55,11 +55,6 @@ class TableTTLStructure
         bool $includeDefaultJobInterval = false
     ): string {
         $query = $this->toAlterQuery($includeDefaultEnable);
-        if (!is_null($this->enable)) {
-            $query .= " TTL_ENABLE = '{$this->enable}'";
-        } elseif ($includeDefaultEnable) {
-            $query .= " TTL_ENABLE = 'ON'";
-        }
         if (!is_null($this->jobInterval)) {
             $query .= " TTL_JOB_INTERVAL = '" . $this->escapeString($this->jobInterval) . "'";
         } elseif ($includeDefaultJobInterval) {


### PR DESCRIPTION
TiDBの独自機能であるテーブルTTLを設定するクエリに対応するプルリクエスト

**対応内容**
- `SHOW CREATE TABLE`からTTL定義を取得
- TTLの追加・変更・削除に対応
- `TTL_ENABLE`と`TTL_JOB_INTERVAL`の変更に対応
- ロールバック時のTTL設定復元に対応

TiDB TTL : https://docs.pingcap.com/ja/tidb/stable/time-to-live/