### PR TITLE
chore: get phpstan, phpcs and phpunit clean on PHP 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /build/
 composer.lock
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor/
 /build/
 composer.lock
-.phpunit.result.cache
+.phpunit.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 
 language: php
 php:
-- 7.3
+- 8.1
 
 before_script:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php":             ">=7.1",
+        "php":             ">=8.1",
         "ext-PDO":         "*",
         "symfony/console": ">=2.0",
         "composer/semver": "^1.4 || ^2.0 || ^3.0"
@@ -50,7 +50,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit":             "^6.2 || ^7.0",
+        "phpunit/phpunit":             "^10.0",
         "symfony/var-dumper":          "^3.3",
         "phpspec/prophecy":            "^1.7",
         "phpstan/phpstan":             "^0.12.5",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "test": "phpunit",
-        "stan": "phpstan analyse -l 7 src",
+        "stan": "phpstan analyse",
         "cs": "phpcs --standard=PSR12 src tests",
         "cbf": "phpcbf --standard=PSR12 src tests",
         "check-fix": [
@@ -53,7 +53,7 @@
         "phpunit/phpunit":             "^10.0",
         "symfony/var-dumper":          "^3.3",
         "phpspec/prophecy":            "^1.7",
-        "phpstan/phpstan":             "^0.12.5",
+        "phpstan/phpstan":             "^2.0",
         "squizlabs/php_codesniffer":   "^3.0",
         "howyi/conv-test-suite":       "dev-master",
         "php-coveralls/php-coveralls": "^2.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,10 @@ services:
 
   mysql-80:
     platform: linux/x86_64
-    image: mysql:8.0
+    # Pinned to 8.0.18: the conv-test-suite fixtures record `int(11)`, and MySQL
+    # 8.0.19 removed the integer display width from the type it reports. Unpin once
+    # those fixtures are gated by server version upstream.
+    image: mysql:8.0.18
     command: mysqld --default-authentication-plugin=mysql_native_password
     security_opt:
     - seccomp:unconfined

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
-FROM php:7.3
+FROM php:8.1
 RUN yes "" | pecl install xdebug-3.1.6 && docker-php-ext-enable xdebug
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends git
+RUN apt-get install -y --no-install-recommends git unzip
 RUN docker-php-ext-install pdo_mysql
+# Run composer on the image PHP so dependencies resolve for the version under test.
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer

--- a/docker/ci.sh
+++ b/docker/ci.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 vendor/bin/phpunit --coverage-clover=build/log/clover.xml
-vendor/bin/phpstan analyse -l 7 src
+vendor/bin/phpstan analyse
 vendor/bin/phpcs --standard=PSR12 src tests
 vendor/bin/php-coveralls -v

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,223 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#1 \$helper of class Howyi\\Conv\\Operator\\ConsoleOperator constructor expects Symfony\\Component\\Console\\Helper\\QuestionHelper, Symfony\\Component\\Console\\Helper\\HelperInterface given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Command/AbstractConvCommand.php
+
+		-
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
+			count: 1
+			path: src/Command/DiffSchema2DbCommand.php
+
+		-
+			message: '#^Cannot call method fetch\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/CreateQueryReflector.php
+
+		-
+			message: '#^Cannot call method fetchAll\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/CreateQueryReflector.php
+
+		-
+			message: '#^Cannot call method fetchAll\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/DatabaseStructureFactory.php
+
+		-
+			message: '#^Parameter \#1 \$query of class class@anonymous/DatabaseStructureFactory\.php\:83 constructor expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DatabaseStructureFactory.php
+
+		-
+			message: '#^Parameter \#1 \$value of function count expects array\|Countable, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DatabaseStructureFactory.php
+
+		-
+			message: '#^Parameter \#1 \$helper of class Howyi\\Conv\\Operator\\ConsoleOperator constructor expects Symfony\\Component\\Console\\Helper\\QuestionHelper, Symfony\\Component\\Console\\Helper\\HelperInterface given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DebugCommand/AbstractCommand.php
+
+		-
+			message: '#^Offset 0 might not exist on array\{\}\|array\{non\-empty\-string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: src/Driver/DriverAllocator.php
+
+		-
+			message: '#^Parameter \#1 \$field of class Howyi\\Conv\\Structure\\ColumnStructure\\MariaDB102ColumnStructure constructor expects string, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Driver/MariaDB102Driver.php
+
+		-
+			message: '#^Cannot call method fetch\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: src/Driver/MySQL56Driver.php
+
+		-
+			message: '#^Cannot call method fetchAll\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: src/Driver/MySQL56Driver.php
+
+		-
+			message: '#^Parameter \#1 \$field of class Howyi\\Conv\\Structure\\ColumnStructure\\MySQL57ColumnStructure constructor expects string, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Driver/MySQL57Driver.php
+
+		-
+			message: '#^Cannot call method fetch\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: src/Driver/TiDBTempDriver.php
+
+		-
+			message: '#^Cannot call method fetchAll\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Driver/TiDBTempDriver.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(mixed\[\]\)\: Unexpected token "\\n     \* ", expected variable at offset 25 on line 2$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Driver/TiDBTempDriver.php
+
+		-
+			message: '#^Parameter \#1 \$field of class Howyi\\Conv\\Structure\\ColumnStructure\\TiDBTempColumnStructure constructor expects string, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Driver/TiDBTempDriver.php
+
+		-
+			message: '#^Binary operation "\+" between int\|string\|false and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: src/Generator/FieldOrderGenerator.php
+
+		-
+			message: '#^Binary operation "\-" between int\|string and int\|string results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: src/Generator/FieldOrderGenerator.php
+
+		-
+			message: '#^Binary operation "\-" between int\|string\|false and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: src/Generator/FieldOrderGenerator.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arg1 of function min expects non\-empty\-array, list\<\(int\|string\)\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Generator/FieldOrderGenerator.php
+
+		-
+			message: '#^Parameter \#2 \$offset of function array_slice expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Generator/FieldOrderGenerator.php
+
+		-
+			message: '#^Parameter \#3 \$length of function array_slice expects int\|null, int\|string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Generator/FieldOrderGenerator.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(IndexAddMigrationLine\)\: Unexpected token "\\n     ", expected variable at offset 39 on line 2$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Migration/Line/IndexAllMigrationLine.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(IndexDropMigrationLine\)\: Unexpected token "\\n     ", expected variable at offset 40 on line 2$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Migration/Line/IndexAllMigrationLine.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(bool\)\: Unexpected token "\\n     ", expected variable at offset 22 on line 2$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Migration/Line/IndexAllMigrationLine.php
+
+		-
+			message: '#^PHPDoc tag @return with type bool is incompatible with native type Howyi\\Conv\\Migration\\Line\\IndexAddMigrationLine\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Migration/Line/IndexAllMigrationLine.php
+
+		-
+			message: '#^PHPDoc tag @return with type bool is incompatible with native type Howyi\\Conv\\Migration\\Line\\IndexDropMigrationLine\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Migration/Line/IndexAllMigrationLine.php
+
+		-
+			message: '#^Property Howyi\\Conv\\Migration\\Table\\ViewRenameMigration\:\:\$isAltered is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Migration/Table/ViewRenameMigration.php
+
+		-
+			message: '#^Method Howyi\\Conv\\Structure\\ColumnStructure\\MySQL56ColumnStructure\:\:getDefault\(\) should return string but returns float\|int\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Structure/ColumnStructure/MySQL56ColumnStructure.php
+
+		-
+			message: '#^Right side of and is always true\.$#'
+			identifier: logicalAnd.rightAlwaysTrue
+			count: 1
+			path: src/Structure/ColumnStructure/MySQL56ColumnStructureTrait.php
+
+		-
+			message: '#^Method Howyi\\Conv\\Structure\\ColumnStructure\\MySQL57ColumnStructure\:\:getDefault\(\) should return string but returns float\|int\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Structure/ColumnStructure/MySQL57ColumnStructure.php
+
+		-
+			message: '#^Method Howyi\\Conv\\Structure\\ColumnStructure\\TiDBTempColumnStructure\:\:getDefault\(\) should return string but returns float\|int\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Structure/ColumnStructure/TiDBTempColumnStructure.php
+
+		-
+			message: '#^Binary operation "\-" between int\|string\|false and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Structure/TableStructure.php
+
+		-
+			message: '#^Method Howyi\\Conv\\Structure\\ViewStructure\:\:getCreateQuery\(\) should return string but returns array\<string\>\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Structure/ViewStructure.php
+
+		-
+			message: '#^Parameter \#1 \$string of function rtrim expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Structure/ViewStructure.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(string\)\: Unexpected token "\\n     ", expected variable at offset 24 on line 2$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Util/FieldOrder.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,15 @@
+parameters:
+    level: 7
+    paths:
+        - src
+
+    # Annotating every property, parameter and array shape in src is a separate
+    # piece of work; exclude those identifiers rather than baseline 162 entries.
+    ignoreErrors:
+        - identifier: missingType.property
+        - identifier: missingType.iterableValue
+        - identifier: missingType.return
+        - identifier: missingType.parameter
+
+includes:
+    - phpstan-baseline.neon

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         forceCoversAnnotation="false"
-         beStrictAboutCoversAnnotation="true"
+         cacheDirectory=".phpunit.cache"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
-    <testsuite name="testsuite">
-        <directory suffix="Test.php">./tests</directory>
-    </testsuite>
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="true">
+    <testsuites>
+        <testsuite name="testsuite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./src/Conv/DebugCommand</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
-<!--    <logging>-->
-<!--        <log type="coverage-html" target="build/log/"/>-->
-<!--    </logging>-->
+        </include>
+        <exclude>
+            <directory>./src/DebugCommand</directory>
+        </exclude>
+    </source>
 </phpunit>

--- a/src/DatabaseStructureFactory.php
+++ b/src/DatabaseStructureFactory.php
@@ -80,7 +80,7 @@ class DatabaseStructureFactory
                 continue;
             }
             $query = file_get_contents($fileInfo->getRealPath());
-            $ddl = new class($query, $pdo, $operator) {
+            $ddl = new class ($query, $pdo, $operator) {
                 private $query;
                 private $isView;
                 private $hasCreated = false;

--- a/src/DebugCommand/SetupCommand.php
+++ b/src/DebugCommand/SetupCommand.php
@@ -41,11 +41,11 @@ class SetupCommand extends AbstractCommand
          );
 
          $pdo = $this->getPDO('conv');
-         foreach ($alter->getMigrationList() as $migration) {
-             $operator->output('<fg=green>実行クエリ</>');
-             $operator->output($migration->getUp());
-             $pdo->exec($migration->getUp());
-         }
+        foreach ($alter->getMigrationList() as $migration) {
+            $operator->output('<fg=green>実行クエリ</>');
+            $operator->output($migration->getUp());
+            $pdo->exec($migration->getUp());
+        }
 
          $output->writeln('<fg=cyan>setup success</>');
 

--- a/src/Driver/DriverAllocator.php
+++ b/src/Driver/DriverAllocator.php
@@ -6,9 +6,9 @@ use Composer\Semver\Semver;
 
 class DriverAllocator
 {
-    const TYPE_MYSQL = 'mysql';
-    const TYPE_MARIA_DB = 'mariadb';
-    const TYPE_TIDB = 'tidb';
+    public const TYPE_MYSQL = 'mysql';
+    public const TYPE_MARIA_DB = 'mariadb';
+    public const TYPE_TIDB = 'tidb';
 
     /**
      * @param \PDO $PDO
@@ -35,7 +35,7 @@ class DriverAllocator
             } else {
                 $version = $split[1];
             }
-        } elseif (strpos($rawVersion, 'TiDB') !== false){
+        } elseif (strpos($rawVersion, 'TiDB') !== false) {
             $type = self::TYPE_TIDB;
             $version = $match[0];
         } elseif (strtolower($driverName) === 'mysql') {
@@ -53,6 +53,7 @@ class DriverAllocator
                     case Semver::satisfies($version, '5.6.*'):
                         return new MySQL56Driver($PDO);
                 }
+                break;
             case self::TYPE_MARIA_DB:
                 switch (true) {
                     case Semver::satisfies($version, '>= 10.2.0'):
@@ -62,6 +63,7 @@ class DriverAllocator
                     case Semver::satisfies($version, '10.0.*'):
                         return new MySQL56Driver($PDO);
                 }
+                break;
             case self::TYPE_TIDB:
                 switch (true) {
                     case Semver::satisfies($version, '>= 8.0.0'):

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -15,7 +15,7 @@ interface DriverInterface
     public function createTableStructure(string $dbName, string $tableName): TableStructure;
 
     /**
-	 * @param string $dbName
+     * @param string $dbName
      * @param string $viewName
      * @return ViewStructure
      */

--- a/src/Driver/MariaDB102Driver.php
+++ b/src/Driver/MariaDB102Driver.php
@@ -6,7 +6,6 @@ use Howyi\Conv\Structure\ColumnStructure\MariaDB102ColumnStructure;
 
 class MariaDB102Driver extends MySQL57Driver
 {
-
     /**
      * {@inheritdoc}
      */

--- a/src/Driver/MySQL56Driver.php
+++ b/src/Driver/MySQL56Driver.php
@@ -210,7 +210,7 @@ EOT;
 
     /**
      * @param string $dbName
-	 * @param string $viewName
+     * @param string $viewName
      * @return ViewStructure
      */
     public function createViewStructure(string $dbName, string $viewName): ViewStructure

--- a/src/Driver/TiDBTempDriver.php
+++ b/src/Driver/TiDBTempDriver.php
@@ -76,12 +76,17 @@ EOT;
             )
         )->fetchAll();
 
-        $rawPkStatus = $this->PDO()->query("SELECT TIDB_ROW_ID_SHARDING_INFO FROM information_schema.TABLES WHERE table_name = '$tableName'")->fetch();
+        $rawPkStatus = $this->PDO()->query(
+            "SELECT TIDB_ROW_ID_SHARDING_INFO FROM information_schema.TABLES WHERE table_name = '$tableName'"
+        )->fetch();
 
         $columnStructureList = [];
 
         foreach ($rawColumnList as $rawColumn) {
-            $columnStructureList[] = $this->createColumnStructure($rawColumn, $rawPkStatus['TIDB_ROW_ID_SHARDING_INFO']);
+            $columnStructureList[] = $this->createColumnStructure(
+                $rawColumn,
+                $rawPkStatus['TIDB_ROW_ID_SHARDING_INFO']
+            );
         }
 
         return $columnStructureList;

--- a/src/Migration/Table/TableMigrationInterface.php
+++ b/src/Migration/Table/TableMigrationInterface.php
@@ -4,7 +4,6 @@ namespace Howyi\Conv\Migration\Table;
 
 interface TableMigrationInterface
 {
-
     /**
      * @return string
      */

--- a/src/MigrationType.php
+++ b/src/MigrationType.php
@@ -4,11 +4,11 @@ namespace Howyi\Conv;
 
 class MigrationType
 {
-    const CREATE            = 0;
-    const ALTER             = 1;
-    const DROP              = 2;
-    const VIEW_CREATE       = 3;
-    const VIEW_DROP         = 4;
-    const CREATE_OR_REPLACE = 5;
-    const VIEW_RENAME       = 6;
+    public const CREATE            = 0;
+    public const ALTER             = 1;
+    public const DROP              = 2;
+    public const VIEW_CREATE       = 3;
+    public const VIEW_DROP         = 4;
+    public const CREATE_OR_REPLACE = 5;
+    public const VIEW_RENAME       = 6;
 }

--- a/src/Structure/Attribute.php
+++ b/src/Structure/Attribute.php
@@ -4,8 +4,8 @@ namespace Howyi\Conv\Structure;
 
 class Attribute
 {
-    const UNSIGNED       = 'unsigned';
-    const NULLABLE       = 'nullable';
-    const AUTO_INCREMENT = 'auto_increment';
-    const STORED         = 'stored';
+    public const UNSIGNED       = 'unsigned';
+    public const NULLABLE       = 'nullable';
+    public const AUTO_INCREMENT = 'auto_increment';
+    public const STORED         = 'stored';
 }

--- a/src/Structure/ColumnStructure/MySQL56ColumnStructureTrait.php
+++ b/src/Structure/ColumnStructure/MySQL56ColumnStructureTrait.php
@@ -109,14 +109,16 @@ trait MySQL56ColumnStructureTrait
      */
     public function isChanged(MySQL56ColumnStructure $target): bool
     {
-        if ($this->type === $target->type and
+        if (
+            $this->type === $target->type and
             $this->comment === $target->comment and
             $this->isNullable() === $target->isNullable() and
             $this->isUnsigned() === $target->isUnsigned() and
             $this->default === $target->default and
             $this->isAutoIncrement() === $target->isAutoIncrement() and
             $this->collationName === $this->collationName and
-            $this->isStored() === $this->isStored()) {
+            $this->isStored() === $this->isStored()
+        ) {
             return false;
         }
         return true;

--- a/src/Structure/ColumnStructure/MySQL57ColumnStructure.php
+++ b/src/Structure/ColumnStructure/MySQL57ColumnStructure.php
@@ -93,7 +93,8 @@ class MySQL57ColumnStructure implements MySQLColumnStructureInterface
      */
     public function isChanged(MySQL57ColumnStructure $target): bool
     {
-        if ($this->type === $target->type and
+        if (
+            $this->type === $target->type and
             $this->comment === $target->comment and
             $this->isNullable() === $target->isNullable() and
             $this->isUnsigned() === $target->isUnsigned() and
@@ -101,7 +102,8 @@ class MySQL57ColumnStructure implements MySQLColumnStructureInterface
             $this->isAutoIncrement() === $target->isAutoIncrement() and
             $this->collationName === $this->collationName and
             $this->generationExpression === $this->generationExpression and
-            $this->isStored() === $this->isStored()) {
+            $this->isStored() === $this->isStored()
+        ) {
             return false;
         }
         return true;

--- a/src/Structure/ColumnStructure/TiDBTempColumnStructure.php
+++ b/src/Structure/ColumnStructure/TiDBTempColumnStructure.php
@@ -84,7 +84,7 @@ class TiDBTempColumnStructure implements MySQLColumnStructureInterface
             }
         }
 
-        if(!is_null($this->auto_random)) {
+        if (!is_null($this->auto_random)) {
             $query[] = $this->auto_random[0] . '(' . $this->auto_random[1] . ',' . $this->auto_random[2] . ')';
         }
 
@@ -99,7 +99,8 @@ class TiDBTempColumnStructure implements MySQLColumnStructureInterface
      */
     public function isChanged(TiDBTempColumnStructure $target): bool
     {
-        if ($this->type === $target->type and
+        if (
+            $this->type === $target->type and
             $this->comment === $target->comment and
             $this->isNullable() === $target->isNullable() and
             $this->isUnsigned() === $target->isUnsigned() and
@@ -107,7 +108,8 @@ class TiDBTempColumnStructure implements MySQLColumnStructureInterface
             $this->isAutoRandom() === $target->isAutoRandom() and
             $this->collationName === $this->collationName and
             $this->generationExpression === $this->generationExpression and
-            $this->isStored() === $this->isStored()) {
+            $this->isStored() === $this->isStored()
+        ) {
             return false;
         }
         return true;

--- a/src/Structure/IndexStructure.php
+++ b/src/Structure/IndexStructure.php
@@ -127,9 +127,11 @@ class IndexStructure
      */
     public function isChanged(IndexStructure $after): bool
     {
-        if ($this->columnNameList === $after->columnNameList and
+        if (
+            $this->columnNameList === $after->columnNameList and
                 $this->isUnique === $after->isUnique and
-                $this->indexType === $after->indexType) {
+                $this->indexType === $after->indexType
+        ) {
             return false;
         }
         return true;

--- a/src/Structure/JoinStructure.php
+++ b/src/Structure/JoinStructure.php
@@ -9,7 +9,7 @@ class JoinStructure
     private $joinArray;
     private $aliasList;
 
-    const MYSQL_OPERATOR = [
+    public const MYSQL_OPERATOR = [
       '=',
       '<=>',
       '<>',

--- a/src/Structure/TableStructureType.php
+++ b/src/Structure/TableStructureType.php
@@ -4,7 +4,7 @@ namespace Howyi\Conv\Structure;
 
 class TableStructureType
 {
-    const TABLE    = 'table';
-    const VIEW     = 'view';
-    const VIEW_RAW = 'view_raw';
+    public const TABLE    = 'table';
+    public const VIEW     = 'view';
+    public const VIEW_RAW = 'view_raw';
 }

--- a/src/Util/PartitionType.php
+++ b/src/Util/PartitionType.php
@@ -4,19 +4,19 @@ namespace Howyi\Conv\Util;
 
 class PartitionType
 {
-    const SHORT = 0;
-    const LONG  = 1;
+    public const SHORT = 0;
+    public const LONG  = 1;
 
-    const KEY           = 'key';
-    const LINEAR_KEY    = 'linear_key';
-    const HASH          = 'hash';
-    const LINEAR_HASH   = 'linear_hash';
-    const LIST          = 'list';
-    const LIST_COLUMNS  = 'list_columns';
-    const RANGE         = 'range';
-    const RANGE_COLUMNS = 'range_columns';
+    public const KEY           = 'key';
+    public const LINEAR_KEY    = 'linear_key';
+    public const HASH          = 'hash';
+    public const LINEAR_HASH   = 'linear_hash';
+    public const LIST          = 'list';
+    public const LIST_COLUMNS  = 'list_columns';
+    public const RANGE         = 'range';
+    public const RANGE_COLUMNS = 'range_columns';
 
-    const METHOD = [
+    public const METHOD = [
       'KEY'           => self::KEY,
       'LINEAR KEY'    => self::LINEAR_KEY,
       'HASH'          => self::HASH,
@@ -27,7 +27,7 @@ class PartitionType
       'RANGE COLUMNS' => self::RANGE_COLUMNS,
     ];
 
-    const METHOD_TYPE = [
+    public const METHOD_TYPE = [
       'KEY'           => self::SHORT,
       'LINEAR KEY'    => self::SHORT,
       'HASH'          => self::SHORT,
@@ -38,7 +38,7 @@ class PartitionType
       'RANGE COLUMNS' => self::LONG,
     ];
 
-    const METHOD_OPERATOR = [
+    public const METHOD_OPERATOR = [
       'LIST'          => 'IN',
       'LIST COLUMNS'  => 'IN',
       'RANGE'         => 'LESS THAN',

--- a/src/Util/SchemaKey.php
+++ b/src/Util/SchemaKey.php
@@ -4,18 +4,18 @@ namespace Howyi\Conv\Util;
 
 class SchemaKey
 {
-    const TABLE_TYPE            = 'type';
-    const TABLE_COMMENT         = 'comment';
-    const TABLE_COLUMN          = 'column';
-    const TABLE_PRIMARY_KEY     = 'primary_key';
-    const TABLE_INDEX           = 'index';
-    const TABLE_ENGINE          = 'engine';
-    const TABLE_DEFAULT_CHARSET = 'default_charset';
-    const TABLE_COLLATE         = 'collate';
-    const TABLE_PARTITION       = 'partition';
-    const TABLE_AUTO_RANDOM     = 'auto_random';
+    public const TABLE_TYPE            = 'type';
+    public const TABLE_COMMENT         = 'comment';
+    public const TABLE_COLUMN          = 'column';
+    public const TABLE_PRIMARY_KEY     = 'primary_key';
+    public const TABLE_INDEX           = 'index';
+    public const TABLE_ENGINE          = 'engine';
+    public const TABLE_DEFAULT_CHARSET = 'default_charset';
+    public const TABLE_COLLATE         = 'collate';
+    public const TABLE_PARTITION       = 'partition';
+    public const TABLE_AUTO_RANDOM     = 'auto_random';
 
-    const TABLE_KEYS = [
+    public const TABLE_KEYS = [
         self::TABLE_TYPE,
         self::TABLE_COMMENT,
         self::TABLE_COLUMN,
@@ -28,12 +28,12 @@ class SchemaKey
         self::TABLE_AUTO_RANDOM,
     ];
 
-    const TABLE_REQUIRE_KEYS = [
+    public const TABLE_REQUIRE_KEYS = [
         self::TABLE_TYPE,
         self::TABLE_COLUMN,
     ];
 
-    const TABLE_OPTIONAL_KEYS = [
+    public const TABLE_OPTIONAL_KEYS = [
         self::TABLE_COMMENT,
         self::TABLE_PRIMARY_KEY,
         self::TABLE_INDEX,
@@ -44,69 +44,69 @@ class SchemaKey
         self::TABLE_AUTO_RANDOM,
     ];
 
-    const COLUMN_TYPE      = 'type';
-    const COLUMN_DEFAULT   = 'default';
-    const COLUMN_COMMENT   = 'comment';
-    const COLUMN_ATTRIBUTE = 'attribute';
+    public const COLUMN_TYPE      = 'type';
+    public const COLUMN_DEFAULT   = 'default';
+    public const COLUMN_COMMENT   = 'comment';
+    public const COLUMN_ATTRIBUTE = 'attribute';
 
-    const COLUMN_KEYS = [
+    public const COLUMN_KEYS = [
         self::COLUMN_TYPE,
         self::COLUMN_DEFAULT,
         self::COLUMN_COMMENT,
         self::COLUMN_ATTRIBUTE,
     ];
 
-    const COLUMN_REQUIRE_KEYS = [
+    public const COLUMN_REQUIRE_KEYS = [
         self::COLUMN_TYPE,
     ];
 
-    const COLUMN_OPTIONAL_KEYS = [
+    public const COLUMN_OPTIONAL_KEYS = [
         self::COLUMN_DEFAULT,
         self::COLUMN_COMMENT,
         self::COLUMN_ATTRIBUTE,
     ];
 
-    const INDEX_TYPE   = 'is_unique';
-    const INDEX_COLUMN = 'column';
+    public const INDEX_TYPE   = 'is_unique';
+    public const INDEX_COLUMN = 'column';
 
-    const INDEX_REQUIRE_KEYS = [
+    public const INDEX_REQUIRE_KEYS = [
         self::INDEX_TYPE,
         self::INDEX_COLUMN,
     ];
 
-    const PARTITION_BY           = 'by';
-    const PARTITION_VALUE        = 'value';
-    const PARTITION_LIST         = 'list';
-    const PARTITION_LESS_THAN    = 'less_than';
-    const PARTITION_IN           = 'in';
-    const PARTITION_ENGINE       = 'engine';
-    const PARTITION_PART_COMMENT = 'comment';
-    const PARTITION_NUM          = 'num';
+    public const PARTITION_BY           = 'by';
+    public const PARTITION_VALUE        = 'value';
+    public const PARTITION_LIST         = 'list';
+    public const PARTITION_LESS_THAN    = 'less_than';
+    public const PARTITION_IN           = 'in';
+    public const PARTITION_ENGINE       = 'engine';
+    public const PARTITION_PART_COMMENT = 'comment';
+    public const PARTITION_NUM          = 'num';
 
-    const VIEW_ALGORITHM = 'algorithm';
-    const VIEW_ALIAS     = 'alias';
-    const VIEW_COLUMN    = 'column';
-    const VIEW_FROM      = 'from';
+    public const VIEW_ALGORITHM = 'algorithm';
+    public const VIEW_ALIAS     = 'alias';
+    public const VIEW_COLUMN    = 'column';
+    public const VIEW_FROM      = 'from';
 
-    const VIEW_KEYS = [
+    public const VIEW_KEYS = [
         self::VIEW_COLUMN,
         self::VIEW_FROM,
         self::VIEW_ALIAS,
     ];
 
-    const VIEW_REQUIRE_KEYS = [
+    public const VIEW_REQUIRE_KEYS = [
         self::VIEW_COLUMN,
         self::VIEW_FROM,
     ];
 
-    const VIEW_OPTIONAL_KEYS = [
+    public const VIEW_OPTIONAL_KEYS = [
         self::VIEW_ALIAS,
     ];
 
-    const JOIN_REFERENCE = 'reference';
-    const JOIN_JOINS     = 'joins';
-    const JOIN_FACTOR    = 'factor';
-    const JOIN_ON        = 'on';
+    public const JOIN_REFERENCE = 'reference';
+    public const JOIN_JOINS     = 'joins';
+    public const JOIN_FACTOR    = 'factor';
+    public const JOIN_ON        = 'on';
 
-    const VIEW_RAW_QUERY = 'query';
+    public const VIEW_RAW_QUERY = 'query';
 }

--- a/tests/Generator/FieldOrderGeneratorTest.php
+++ b/tests/Generator/FieldOrderGeneratorTest.php
@@ -15,7 +15,7 @@ class FieldOrderGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function generateProvider()
+    public static function generateProvider()
     {
         return [
             [
@@ -57,7 +57,7 @@ class FieldOrderGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function onesideProvider()
+    public static function onesideProvider()
     {
         return [
             [

--- a/tests/Generator/IndexMigrationGeneratorTest.php
+++ b/tests/Generator/IndexMigrationGeneratorTest.php
@@ -18,7 +18,7 @@ class IndexMigrationGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function generateProvider()
+    public static function generateProvider()
     {
         return [
             [

--- a/tests/MigrationGeneratorMultiTest.php
+++ b/tests/MigrationGeneratorMultiTest.php
@@ -16,12 +16,12 @@ class MigrationGeneratorMultiTest extends \PHPUnit\Framework\TestCase
 {
     private $prophet;
 
-    protected function setup()
+    protected function setUp(): void
     {
         $this->prophet = new \Prophecy\Prophet();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->prophet->checkPredictions();
     }

--- a/tests/MigrationGeneratorMultiTest.php
+++ b/tests/MigrationGeneratorMultiTest.php
@@ -71,7 +71,7 @@ class MigrationGeneratorMultiTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function generateProvider()
+    public static function generateProvider()
     {
         $values = [
             [

--- a/tests/MigrationGeneratorSingleTest.php
+++ b/tests/MigrationGeneratorSingleTest.php
@@ -101,7 +101,7 @@ class MigrationGeneratorSingleTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function generateProvider()
+    public static function generateProvider()
     {
         $dir = 'vendor/howyi/conv-test-suite/cases/part/';
 

--- a/tests/MigrationGeneratorSingleTest.php
+++ b/tests/MigrationGeneratorSingleTest.php
@@ -10,12 +10,12 @@ class MigrationGeneratorSingleTest extends \PHPUnit\Framework\TestCase
 {
     private $prophet;
 
-    protected function setup()
+    protected function setUp(): void
     {
         $this->prophet = new \Prophecy\Prophet();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->prophet->checkPredictions();
     }

--- a/tests/Operator/ConsoleOperatorTest.php
+++ b/tests/Operator/ConsoleOperatorTest.php
@@ -17,7 +17,7 @@ class ConsoleOperatorTest extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setup()
+    protected function setUp(): void
     {
         $this->prophet = new \Prophecy\Prophet();
     }
@@ -25,7 +25,7 @@ class ConsoleOperatorTest extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->prophet->checkPredictions();
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 set_time_limit(0);
 
 require dirname(__FILE__) . '/../vendor/autoload.php';


### PR DESCRIPTION
Stacked on #67. This clears the three follow-ups
noted there, so `docker/ci.sh` runs end to end again. Three commits, one per tool,
reviewable independently.

## phpstan

`^0.12.5` (0.12.100) cannot run under PHP 8.1: it emits deprecations of its own, and
its parser does not understand the PHP 8 syntax in vendor, reporting 226 syntax
errors instead of analysing `src`. Bumped to `^2.0` (2.2.13).

Level and paths move into `phpstan.neon` so the two call sites no longer repeat them,
and `composer stan` / `ci.sh` become plain `phpstan analyse`.

phpstan 2.x reports 210 errors at level 7 on `src`. They split cleanly:

| kind | count | handling |
| --- | --- | --- |
| `missingType.*` | 162 | excluded by identifier in phpstan.neon |
| everything else | 48 | `phpstan-baseline.neon` |

Annotating every property and array shape in `src` is its own piece of work, so those
identifiers are excluded rather than baselined - 162 baseline entries would make the
file churn on every edit. The remaining 48 are held in a baseline so new code is
checked at level 7 while they are worked through.

## php_codesniffer

The version resolved on PHP 8.1 (3.13.6) reports 20 errors and 76 warnings the old one
did not. 18 are formatting and were fixed by `phpcbf`. The rest:

- **Constant visibility (74).** Declared `public` on the class constants. PSR-12 has
  asked for this since PHP 7.1 and the requirement is now 8.1.
- **Line length (2)** in `TiDBTempDriver`. Wrapped, matching the multi-line
  `query(...)` style already used a few lines above.
- **Switch fall-through (2)** in `DriverAllocator::fromPDO()`. phpcs wanted either a
  `// no break` comment or a `break`, and the fall-through is not intentional: an
  unsupported version fell out of the MySQL case into the MariaDB and TiDB cases and
  was tested against their version ranges. Added `break`. No behaviour change today,
  since those ranges do not overlap and every path still reaches the same
  `RuntimeException` - but a case added to one inner switch would silently have caught
  servers of another type.

## PHPUnit

- The five data provider methods are now `static`. PHPUnit 10 deprecates non-static
  providers and PHPUnit 11 rejects them; none of them touched `$this`.
- `phpunit.xml` migrated to the 10.5 schema via `--migrate-configuration`.
  `<filter><whitelist>` becomes `<source>`, and the removed `verbose` and
  `forceCoversAnnotation` attributes are gone.
- The coverage exclude path read `./src/Conv/DebugCommand`, which has never existed,
  so `DebugCommand` was being measured. Corrected to `./src/DebugCommand`.
- `.gitignore` tracks `.phpunit.cache/`, since the migrated config sets
  `cacheDirectory`.

## Testing

All three steps of `docker/ci.sh` on PHP 8.1:

```
vendor/bin/phpunit --coverage-clover=build/log/clover.xml   OK (111 tests, 277 assertions)   exit 0
vendor/bin/phpstan analyse                                  [OK] No errors                  exit 0
vendor/bin/phpcs --standard=PSR12 src tests                                                 exit 0
```

No PHPUnit deprecations remain, and the Clover report is still produced.

## Found while doing this, not fixed here

`isChanged()` compares three fields against itself rather than against `$target`, so
those fields can never register as changed:

```
src/Structure/ColumnStructure/MySQL56ColumnStructureTrait.php:119  $this->collationName === $this->collationName
src/Structure/ColumnStructure/MySQL56ColumnStructureTrait.php:120  $this->isStored() === $this->isStored()
src/Structure/ColumnStructure/MySQL57ColumnStructure.php:103-105   collationName, generationExpression, isStored
src/Structure/ColumnStructure/TiDBTempColumnStructure.php:109-111  collationName, generationExpression, isStored
```

If that reading is right, conv silently skips migrations for collation changes,
generated-column expression changes, and STORED/VIRTUAL changes. It is one of the 48
baselined phpstan findings (`logicalAnd.rightAlwaysTrue`). Left alone here because
fixing it changes what migrations conv emits and wants its own tests - happy to open
a separate PR if you would like.
