### PR TITLE
fix: sort DDL files by name so generation does not depend on readdir order

### DIFF
--- a/src/DatabaseStructureFactory.php
+++ b/src/DatabaseStructureFactory.php
@@ -72,7 +72,12 @@ class DatabaseStructureFactory
 
         $operator->startProgress(count(glob("$path/*.sql")));
         $ddls = [];
-        foreach (new \DirectoryIterator($path) as $fileInfo) {
+        // DirectoryIterator::current() returns $this, so iterator_to_array() would
+        // fill the array with references to a single (already exhausted) iterator.
+        // FilesystemIterator yields a fresh SplFileInfo per entry and skips dot entries.
+        $files = iterator_to_array(new \FilesystemIterator($path), false);
+        usort($files, fn(\SplFileInfo $a, \SplFileInfo $b) => strcmp($a->getFilename(), $b->getFilename()));
+        foreach ($files as $fileInfo) {
             if (!$fileInfo->isFile()) {
                 continue;
             }


### PR DESCRIPTION
## Problem

`conv:generate` (via conv-laravel) started failing after switching Docker Desktop
from the Hyper-V backend to the WSL2 backend. The DDL directory and the SQL files
in it were unchanged.

## Cause

`DatabaseStructureFactory::fromSqlDir()` iterated the DDL directory with
`DirectoryIterator` and used whatever order `readdir()` returned. That order is not
guaranteed: the Hyper-V backend happened to return entries in name order, while the
WSL2 backend's bind mount does not. Since that order decides the order `$ddls` is
built in, and therefore the order the tables are created in, the result was no
longer reproducible across environments.

## Fix

Collect the entries and sort them by filename before building `$ddls`, so the
creation order is deterministic regardless of the filesystem.

`FilesystemIterator` is used rather than `DirectoryIterator` on purpose:
`DirectoryIterator::current()` returns `$this`, so its entries cannot be collected
into an array for sorting - `iterator_to_array()` yields N references to a single,
already exhausted iterator, and every element reads back as an empty
`DirectoryIterator`. `FilesystemIterator::current()` returns a fresh `SplFileInfo`
per entry and skips the dot entries by default, so the existing `isFile()` /
`getExtension()` / `getRealPath()` / `getBaseName('.sql')` calls in the loop are
unaffected.

A plain closure is used instead of an arrow function to stay within the
`"php": ">=7.1"` requirement in composer.json.

## Testing

- `conv:generate` succeeds again on the Docker Desktop WSL2 backend.
- `php -l` passes on PHP 7.3, the version used by `docker/Dockerfile`.
